### PR TITLE
Fix formatting in VoiceKit component

### DIFF
--- a/esphome/components/voice_kit/voice_kit.cpp
+++ b/esphome/components/voice_kit/voice_kit.cpp
@@ -113,7 +113,7 @@ PipelineStages VoiceKit::read_pipeline_stage(MicrophoneChannels channel) {
 void VoiceKit::write_pipeline_stages() {
   // Write channel 0 stage
   uint8_t stage_set[] = {CONFIGURATION_SERVICER_RESID, CONFIGURATION_SERVICER_RESID_CHANNEL_0_PIPELINE_STAGE, 1,
-                               this->channel_0_stage_};
+                         this->channel_0_stage_};
 
   auto error_code = this->write(stage_set, sizeof(stage_set));
   if (error_code != i2c::ERROR_OK) {


### PR DESCRIPTION
## Summary
- fix clang-format issue in `voice_kit.cpp`

## Testing
- `clang-format --dry-run esphome/components/voice_kit/voice_kit.cpp`
- `pip install yamllint` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_b_687b9a7b5b28832dae7fb2b6bbdd3039