### PR TITLE
Fix trailing spaces causing yamllint failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python + ESPHome
         run: |
           python -m pip install --upgrade pip
-          pip install esphome==2025.6.0            
+          pip install esphome==2025.6.0
 
       - name: Compile factory & OTA
         run: |


### PR DESCRIPTION
## Summary
- remove trailing whitespace from `build.yml`

## Testing
- `yamllint --strict .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687b9bcb54cc832d97863955dd67aadf